### PR TITLE
Fix linux signature for RespawnDeadPlayers

### DIFF
--- a/gamedata/norespawn.games.txt
+++ b/gamedata/norespawn.games.txt
@@ -8,7 +8,7 @@
 			{
 				"library"		"server"
 				"windows"		"\xA1\x2A\x2A\x2A\x2A\x83\x78\x30\x00\x74\x2A\xA1\x2A\x2A\x2A\x2A\x83\x78\x30\x00\x0F\x84"
-				"linux"			"@_ZN16CNMRiH_GameRules14RespawnPlayersEv"
+				"linux"			"@_ZN16CNMRiH_GameRules18RespawnDeadPlayersEb"
 			}
 		}
 


### PR DESCRIPTION
Change the linux signature for respawndeadplayers from @_ZN16CNMRiH_GameRules14RespawnPlayersEv to @_ZN16CNMRiH_GameRules18RespawnDeadPlayersEb.
The previous signature prevented proper spawn at round start and when restarting. Results were that players didnt respawn properly and they had broken viewmodels.